### PR TITLE
feat(mep): Implement `build_snql_query` for sessions

### DIFF
--- a/src/sentry/search/events/builder.py
+++ b/src/sentry/search/events/builder.py
@@ -1555,6 +1555,13 @@ class HistogramQueryBuilder(QueryBuilder):
         return base_groupby
 
 
+class SessionsQueryBuilder(QueryBuilder):
+    def resolve_params(self) -> List[WhereType]:
+        conditions = super().resolve_params()
+        conditions.append(Condition(self.column("org_id"), Op.EQ, self.organization_id))
+        return conditions
+
+
 class MetricsQueryBuilder(QueryBuilder):
     def __init__(
         self,

--- a/src/sentry/search/events/datasets/sessions.py
+++ b/src/sentry/search/events/datasets/sessions.py
@@ -1,11 +1,13 @@
 from typing import Callable, Mapping, Optional
 
+from snuba_sdk import Function
+
 from sentry.api.event_search import SearchFilter
 from sentry.search.events.builder import QueryBuilder
 from sentry.search.events.constants import RELEASE_ALIAS
 from sentry.search.events.datasets import filter_aliases
 from sentry.search.events.datasets.base import DatasetConfig
-from sentry.search.events.fields import SnQLFunction
+from sentry.search.events.fields import SessionColumnArg, SnQLFunction
 from sentry.search.events.types import SelectType, WhereType
 
 
@@ -27,7 +29,34 @@ class SessionsDatasetConfig(DatasetConfig):
 
     @property
     def function_converter(self) -> Mapping[str, SnQLFunction]:
-        return {}
+        return {
+            function.name: function
+            for function in [
+                SnQLFunction(
+                    "percentage",
+                    required_args=[SessionColumnArg("numerator"), SessionColumnArg("denominator")],
+                    # Since percentage is only used on aggregates, it needs to be an aggregate and not a column
+                    # This is because as a column it will be added to the `WHERE` clause instead of the `HAVING` clause
+                    snql_aggregate=lambda args, alias: Function(
+                        "if",
+                        parameters=[
+                            Function("greater", parameters=[args["denominator"], 0]),
+                            Function("divide", parameters=[args["numerator"], args["denominator"]]),
+                            None,
+                        ],
+                        alias=alias,
+                    ),
+                    default_result_type="percentage",
+                ),
+                SnQLFunction(
+                    "identity",
+                    required_args=[SessionColumnArg("column")],
+                    snql_aggregate=lambda args, alias: Function(
+                        "identity", parameters=[args["column"]], alias=alias
+                    ),
+                ),
+            ]
+        }
 
     def _release_filter_converter(self, search_filter: SearchFilter) -> Optional[WhereType]:
         return filter_aliases.release_filter_converter(self.builder, search_filter)

--- a/src/sentry/utils/snuba.py
+++ b/src/sentry/utils/snuba.py
@@ -86,7 +86,16 @@ TRANSACTIONS_SNUBA_MAP = {
     if col.value.transaction_name is not None
 }
 
-SESSIONS_FIELD_LIST = ["release", "sessions", "sessions_crashed", "users", "users_crashed"]
+SESSIONS_FIELD_LIST = [
+    "release",
+    "sessions",
+    "sessions_crashed",
+    "users",
+    "users_crashed",
+    "project_id",
+    "org_id",
+    "environment",
+]
 
 SESSIONS_SNUBA_MAP = {column: column for column in SESSIONS_FIELD_LIST}
 


### PR DESCRIPTION
<!-- Describe your PR here. -->

Follow-up to https://github.com/getsentry/sentry/pull/35537. Implements build_snql_query for
sessions. Same general methodologies and logic from the previous pr apply.

해당 내용은 PR원문을 들고왔습니다.

<!--

-->
https://getsentry.github.io/snuba/index.html
snql은 snuba query로 sentry에서 postgres와 redis 사용을 대체하기 위해 나왔습니다.
